### PR TITLE
Added compile errors if the test_case or section names are empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-catch"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Guy Dunton PC <guy.dunton@gmail.com>"]
 edition = "2018"
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -171,6 +171,16 @@ test_suite! {
 }
 
 /*
+// This will give an error but will highlight the test_case name only
+test_suite! {
+    test_case("") {
+        section("") {
+        }
+    }
+}
+*/
+
+/*
 
 #[test_case]
 test "" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate proc_macro;
 use quote::quote;
 use syn::parse_macro_input;
 
+mod names;
 mod section;
 mod test_case;
 mod test_suite;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,0 +1,10 @@
+use syn::{Error, Ident, LitStr};
+
+pub fn name_as_ident2(construct_name: &str, name: &LitStr) -> syn::Result<Ident> {
+    if name.value().is_empty() {
+        let text = format!("{} names cannot be empty. \n\n Hint: Try to use a descriptive name such as \"Vec can be resized\".\n", construct_name);
+        return Err(Error::new(name.span(), text));
+    }
+    let text = name.value().replace(' ', "_");
+    Ok(Ident::new(&text[..], name.span()))
+}

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,3 +1,4 @@
+use super::names::name_as_ident2;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{braced, parenthesized, Block, Ident, LitStr, Stmt};
@@ -30,11 +31,6 @@ impl Parse for Section {
     }
 }
 
-fn name_as_ident(name: &LitStr) -> Ident {
-    let text = name.value().replace(' ', "_");
-    Ident::new(&text[..], name.span())
-}
-
 impl ToTokens for Section {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let code = self.code.clone();
@@ -55,8 +51,8 @@ impl IndexSection {
         IndexSection { index, section }
     }
 
-    pub fn name(&self) -> Ident {
-        name_as_ident(&self.section.name)
+    pub fn name(&self) -> Result<Ident> {
+        name_as_ident2("section", &self.section.name)
     }
 
     pub fn index(&self) -> u32 {


### PR DESCRIPTION
Added errors for empty titles so that things like this:
```rust
test_suite! {
   test_case("") {
    }
}
```
Give an error but only over the `""` instead of the whole `test_suite!`.
This will fix #7.